### PR TITLE
feat(craft3): Support for latest CraftCMS v3 (3.9.13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Introduction
-Simple driver setup for CraftCMS components queue, cache or session for CraftCMS v4 and v5.
+Simple driver setup for CraftCMS components queue, cache or session for CraftCMS v3, v4 and v5.
 
 Available components and drivers
 
@@ -13,7 +13,8 @@ Available components and drivers
 > Craft's default queue driver is the database.
 > Do not configure the queue component in the app.php if you want to make use of the database queue driver.
 > 
-> Craft v4: https://craftcms.com/docs/4.x/config/app.html#queue <br>
+> Craft v3: https://craftcms.com/docs/3.x/config/#queue-component <br />
+> Craft v4: https://craftcms.com/docs/4.x/config/app.html#queue <br />
 > Craft v5: https://craftcms.com/docs/5.x/reference/config/app.html#queue
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "craftcms/cms": "^4.0|^5.0"
+    "craftcms/cms": "^3.9.13|^4.0|^5.0"
   },
   "require-dev": {
     "craftcms/phpstan": "dev-main",
@@ -33,7 +33,7 @@
     "yiisoft/yii2-redis": "Required to use Redis with Craft CMS (^2.0.18)."
   },
   "conflict": {
-    "craftcms/cms": "<4.0.0"
+    "craftcms/cms": "<3.9.13"
   },
   "scripts": {
     "test:types": "./vendor/bin/phpstan analyse --memory-limit=1G"

--- a/docs/examples/app.php
+++ b/docs/examples/app.php
@@ -13,5 +13,5 @@ return [
         'redis' => Redis::connect(),
         'cache' => fn () => Cache::driver('redis'),
         'queue' => Queue::driver('redis'),
-    ]
+    ],
 ];

--- a/src/Components/Cache.php
+++ b/src/Components/Cache.php
@@ -21,7 +21,7 @@ class Cache extends Component
     protected static function redis(): YiiRedisCache
     {
         $redis = Redis::connect();
-        $redis['database'] = App::env('REDIS_CACHE_DB') ?? 1;
+        $redis['database'] = App::env('REDIS_CACHE_DB') ?: 1;
 
         return Craft::createObject([
             'class' => YiiRedisCache::class,

--- a/src/Components/Queue.php
+++ b/src/Components/Queue.php
@@ -7,6 +7,8 @@ namespace Verplanke\CraftComponents\Components;
 use craft\helpers\App;
 use Verplanke\CraftComponents\Component;
 use Verplanke\CraftComponents\Exceptions\QueueException;
+use yii\queue\redis\Queue as YiiRedisQueue;
+use function Verplanke\CraftComponents\isCraft3;
 
 class Queue extends Component
 {
@@ -19,17 +21,19 @@ class Queue extends Component
     protected static function redis(): array
     {
         $redis = Redis::connect();
-        $redis['database'] = App::env('REDIS_QUEUE_DB') ?? 3;
+        $redis['database'] = App::env('REDIS_QUEUE_DB') ?: 3;
 
-        return [
-            'proxyQueue' => [
-                'class' => \yii\queue\redis\Queue::class,
-                'redis' => $redis,
-                'channel' => App::env('REDIS_QUEUE_CHANNEL') ?? 'queue',
-                'ttr' => App::env('REDIS_QUEUE_TTR') ?? 300,
-                'attempts' => App::env('REDIS_QUEUE_ATTEMPTS') ?? 3,
-            ],
+        $config = [
+            'class' => YiiRedisQueue::class,
+            'redis' => $redis,
+            'channel' => App::env('REDIS_QUEUE_CHANNEL') ?: 'queue',
+            'ttr' => App::env('REDIS_QUEUE_TTR') ?: 300,
+            'attempts' => App::env('REDIS_QUEUE_ATTEMPTS') ?: 3,
         ];
+
+        return isCraft3()
+            ? $config
+            : ['proxyQueue' => $config];
     }
 
     /**

--- a/src/Components/Queue.php
+++ b/src/Components/Queue.php
@@ -31,9 +31,9 @@ class Queue extends Component
             'attempts' => App::env('REDIS_QUEUE_ATTEMPTS') ?: 3,
         ];
 
-        return isCraft3()
-            ? $config
-            : ['proxyQueue' => $config];
+        return ! defined('Craft::Personal')
+            ? ['proxyQueue' => $config]
+            : $config;
     }
 
     /**

--- a/src/Components/Redis.php
+++ b/src/Components/Redis.php
@@ -63,13 +63,13 @@ class Redis
             'hostname' => $urlComponents['hostname'],
             'port' => $urlComponents['port'],
             'password' => $urlComponents['password'],
-            'useSSL' => App::env('REDIS_SSL') ?? false,
-            'retries' => App::env('REDIS_RETRIES') ?? 1,
-            'database' => App::env('REDIS_DB') ?? 0,
+            'useSSL' => App::env('REDIS_SSL') ?: false,
+            'retries' => App::env('REDIS_RETRIES') ?: 1,
+            'database' => App::env('REDIS_DB') ?: 0,
             'contextOptions' => [
                 'ssl' => [
-                    'verify_peer' => App::env('REDIS_SSL_VERIFY_PEER') ?? false,
-                    'verify_peer_name' => App::env('REDIS_SSL_VERIFY_PEER_NAME') ?? false,
+                    'verify_peer' => App::env('REDIS_SSL_VERIFY_PEER') ?: false,
+                    'verify_peer_name' => App::env('REDIS_SSL_VERIFY_PEER_NAME') ?: false,
                 ],
             ],
         ];
@@ -81,7 +81,7 @@ class Redis
      */
     private static function parseUrl(): array
     {
-        $parsed = parse_url(App::env('REDIS_URL') ?? '');
+        $parsed = parse_url(App::env('REDIS_URL') ?: '');
 
         $scheme = match ($parsed['scheme'] ?? null) {
             'rediss' => 'tls',
@@ -90,10 +90,10 @@ class Redis
 
         return [
             'scheme' => $scheme,
-            'hostname' => $parsed['host'] ?? App::env('REDIS_HOST') ?? $parsed['path'] ?? null,
-            'port' => $parsed['port'] ?? App::env('REDIS_PORT') ?? 6379,
+            'hostname' => $parsed['host'] ?? App::env('REDIS_HOST') ?: $parsed['path'] ?? null,
+            'port' => $parsed['port'] ?? App::env('REDIS_PORT') ?: 6379,
             'user' => $parsed['user'] ?? null,
-            'password' => $parsed['pass'] ?? App::env('REDIS_PASSWORD') ?? null,
+            'password' => $parsed['pass'] ?? App::env('REDIS_PASSWORD') ?: null,
         ];
     }
 

--- a/src/Components/Session.php
+++ b/src/Components/Session.php
@@ -22,7 +22,7 @@ class Session extends Component
     public static function redis(): YiiRedisSession
     {
         $redis = Redis::connect();
-        $redis['database'] = App::env('REDIS_SESSION_DB') ?? 2;
+        $redis['database'] = App::env('REDIS_SESSION_DB') ?: 2;
 
         $config = array_merge(self::config(), [
             'class' => YiiRedisSession::class,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,3 +10,8 @@ function class_basename(object|string $class): string
 
     return basename(str_replace('\\', '/', $class));
 }
+
+function isCraft3(): bool
+{
+    return defined('Craft::Personal');
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,8 +10,3 @@ function class_basename(object|string $class): string
 
     return basename(str_replace('\\', '/', $class));
 }
-
-function isCraft3(): bool
-{
-    return defined('Craft::Personal');
-}


### PR DESCRIPTION

- added support for latest CraftCMS v3 by checking if `Craft::Personal` constant is defined. The constant `Craft::Personal` is only defined in Craft v3 and removed in Craft v4