### PR TITLE
feat(driver-selection): Select driver by environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,71 @@ composer require yiisoft/yii2-redis
 ## Configuration
 To make use of a different driver per component is a breeze. Just specify the desired driver for the component you want to use in the `components` config array in either `config/app.php` or `config/app.web.php` (session only).
 
-If you want to use the Redis driver for a specific component, make sure Redis is configured.
+### Database configuration
+In order to use the `database` driver, configure CraftCMS as followed
+
+### Cache component
+```php
+// .env
+CRAFT_CACHE_DRIVER=database
+
+// config/app.php
+
+use craft\helpers\App;
+use Verplanke\CraftComponents\Components\Cache;
+
+return [
+    'components' => [
+        'cache' => fn () => Cache::driver(App::env('CRAFT_CACHE_DRIVER')),
+    ],
+];
+```
+
+### Queue component
+
+```php
+// .env
+CRAFT_QUEUE_DRIVER=database
+
+// config/app.php
+
+use craft\helpers\App;
+use Verplanke\CraftComponents\Components\Queue;
+
+return [
+    'components' => [
+        'queue' => Queue::driver(App::env('CRAFT_QUEUE_DRIVER')),
+    ],
+];
+```
+
+### Session component
+
+```php
+// .env
+CRAFT_SESSION_DRIVER=database
+
+// config/app.web.php
+
+use craft\helpers\App;
+use Verplanke\CraftComponents\Components\Session;
+
+return [
+    'components' => [
+        'session' => fn () => Session::driver(App::env('CRAFT_SESSION_DRIVER')),
+    ],
+];
+```
 
 ### Redis configuration
+If you want to use the `Redis` driver for a specific component, make sure Redis is configured
+
 1. Add the Redis component to the `app.php`, see example below
 2. Enable Redis by adding the following environment variables
-   - `REDIS_ENABLED=true`
    - `REDIS_URL=` OR `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD`
 
-`REDIS_URL` takes precedence over `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD`.
+> [!NOTE]
+> `REDIS_URL` takes precedence over `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD`.
 ```php
 // config/app.php
 
@@ -54,13 +110,17 @@ return [
 ### Cache component
 
 ```php
+// .env
+CRAFT_CACHE_DRIVER=redis
+
 // config/app.php
 
+use craft\helpers\App;
 use Verplanke\CraftComponents\Components\Cache;
 
 return [
     'components' => [
-        'cache' => fn () => Cache::driver('redis'),
+        'cache' => fn () => Cache::driver(App::env('CRAFT_CACHE_DRIVER')),
     ],
 ];
 ```
@@ -68,13 +128,17 @@ return [
 ### Queue component
 
 ```php
+// .env
+CRAFT_QUEUE_DRIVER=redis
+
 // config/app.php
 
+use craft\helpers\App;
 use Verplanke\CraftComponents\Components\Queue;
 
 return [
     'components' => [
-        'queue' => Queue::driver('redis'),
+        'queue' => Queue::driver(App::env('CRAFT_QUEUE_DRIVER')),
     ],
 ];
 ```
@@ -82,13 +146,17 @@ return [
 ### Session component
 
 ```php
+// .env
+CRAFT_SESSION_DRIVER=redis
+
 // config/app.web.php
 
+use craft\helpers\App;
 use Verplanke\CraftComponents\Components\Session;
 
 return [
     'components' => [
-        'session' => fn () => Session::driver('redis'),
+        'session' => fn () => Session::driver(App::env('CRAFT_SESSION_DRIVER')),
     ],
 ];
 ```
@@ -101,22 +169,24 @@ It's recommended to leave the following set to `false` when using Heroku. [Herok
 - `REDIS_SSL_VERIFY_PEER_NAME`
 
 
-|                              |      Required       |  Type   | Default Value | Description / Remark                                                                                                        |
-|:-----------------------------|:-------------------:|:-------:|:-------------:|-----------------------------------------------------------------------------------------------------------------------------|
-| `REDIS_ENABLED`              | :white_check_mark:  | boolean |               |                                                                                                                             |
-| `REDIS_URL`                  | :white_check_mark:  | string  |               | Takes precedence over `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD`.                                                      |
-| `REDIS_HOST`                 |                     | string  |               | **Only when `REDIS_URL` is not used**                                                                                       |
-| `REDIS_PORT`                 |                     | string  |     6379      | **Only when `REDIS_URL` is not used**                                                                                       |
-| `REDIS_PASSWORD`             |                     | string  |               | **Only when `REDIS_URL` is not used**                                                                                       |
-| `REDIS_DB`                   |                     | integer |       0       | Default database to use, this database will be used for all Redis connections                                               |  
-| `REDIS_RETRIES`              |                     | integer |       1       | Th..ount of times to retry connecting after connection has timed out                                                        |
-| `REDIS_SSL`                  |                     | boolean |     false     | Use SSL connection when connecting with Redis. Recommended to use `false` when using Heroku                                 |
-| `REDIS_SSL_VERIFY_PEER`      |                     | boolean |     false     | Verify peer SSL certificate. Recommended to use `false` when using Heroku                                                   |
-| `REDIS_SSL_VERIFY_PEER_NAME` |                     | boolean |     false     | Verify peer name of SSL certificate. Recommended to use `false` when using Heroku                                           |
-| `REDIS_CACHE_DB`             |                     | integer |       1       | Which database to use for the cache database. Make sure the cache database is separated from the queue and session database |
-| `REDIS_QUEUE_DB`             |                     | integer |       3       | Which database to use for the queue database                                                                                |
-| `REDIS_QUEUE_CHANNEL`        |                     | string  |     queue     | Queue channel to use                                                                                                        |
-| `REDIS_QUEUE_TTR`            |                     | integer |      300      | Max time for job execution, unit in seconds                                                                                 |
-| `REDIS_QUEUE_ATTEMPTS`       |                     | integer |       3       | Max number of attempts                                                                                                      |
-| `REDIS_SESSION_DB`           |                     | integer |       1       | Which database to use for the session database.                                                                             |
+|                              |      Required      |  Type   | Default Value | Description / Remark                                                                                                        |
+|:-----------------------------|:------------------:|:-------:|:-------------:|-----------------------------------------------------------------------------------------------------------------------------|
+| `CRAFT_CACHE_DRIVER`         | :white_check_mark: | string  |               | Possible values `redis` or `database`                                                                                       |
+| `CRAFT_SESSION_DRIVER`       | :white_check_mark: | string  |               | Possible values `redis` or `database`                                                                                       |
+| `CRAFT_QUEUE_DRIVER`         | :white_check_mark: | string  |               | Possible values `redis` or `database`                                                                                       |
+| `REDIS_URL`                  | :white_check_mark: | string  |               | Takes precedence over `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD`.                                                      |
+| `REDIS_HOST`                 |                    | string  |               | **Only when `REDIS_URL` is not used**                                                                                       |
+| `REDIS_PORT`                 |                    | string  |     6379      | **Only when `REDIS_URL` is not used**                                                                                       |
+| `REDIS_PASSWORD`             |                    | string  |               | **Only when `REDIS_URL` is not used**                                                                                       |
+| `REDIS_DB`                   |                    | integer |       0       | Default database to use, this database will be used for all Redis connections                                               |  
+| `REDIS_RETRIES`              |                    | integer |       1       | Th..ount of times to retry connecting after connection has timed out                                                        |
+| `REDIS_SSL`                  |                    | boolean |     false     | Use SSL connection when connecting with Redis. Recommended to use `false` when using Heroku                                 |
+| `REDIS_SSL_VERIFY_PEER`      |                    | boolean |     false     | Verify peer SSL certificate. Recommended to use `false` when using Heroku                                                   |
+| `REDIS_SSL_VERIFY_PEER_NAME` |                    | boolean |     false     | Verify peer name of SSL certificate. Recommended to use `false` when using Heroku                                           |
+| `REDIS_CACHE_DB`             |                    | integer |       1       | Which database to use for the cache database. Make sure the cache database is separated from the queue and session database |
+| `REDIS_QUEUE_DB`             |                    | integer |       3       | Which database to use for the queue database                                                                                |
+| `REDIS_QUEUE_CHANNEL`        |                    | string  |     queue     | Queue channel to use                                                                                                        |
+| `REDIS_QUEUE_TTR`            |                    | integer |      300      | Max time for job execution, unit in seconds                                                                                 |
+| `REDIS_QUEUE_ATTEMPTS`       |                    | integer |       3       | Max number of attempts                                                                                                      |
+| `REDIS_SESSION_DB`           |                    | integer |       1       | Which database to use for the session database.                                                                             |
 

--- a/src/Components/Queue.php
+++ b/src/Components/Queue.php
@@ -8,7 +8,6 @@ use craft\helpers\App;
 use Verplanke\CraftComponents\Component;
 use Verplanke\CraftComponents\Exceptions\QueueException;
 use yii\queue\redis\Queue as YiiRedisQueue;
-use function Verplanke\CraftComponents\isCraft3;
 
 class Queue extends Component
 {

--- a/src/Components/Redis.php
+++ b/src/Components/Redis.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Verplanke\CraftComponents\Components;
 
 use craft\helpers\App;
-use Exception;
 use Verplanke\CraftComponents\Exceptions\RedisException;
 use Throwable;
 use yii\redis\Connection;
@@ -22,10 +21,6 @@ class Redis
     public static function connect(): array
     {
         try {
-            if (! Redis::isEnabled()) {
-                throw new Exception('Redis is not enabled. Enable Redis using environment variable REDIS_ENABLED');
-            }
-
             Redis::ensureRedisExtensionIsEnabled();
             Redis::ensureYiiRedisExtensionIsInstalled();
 
@@ -37,17 +32,6 @@ class Redis
 
             throw $throwable;
         }
-    }
-
-    /**
-     * @throws \yii\base\Exception
-     */
-    public static function isEnabled(): bool
-    {
-        return match (App::env('REDIS_ENABLED')) {
-            true, 'true', 0 => true,
-            default => false,
-        };
     }
 
     /**


### PR DESCRIPTION
- added option to select component driver by defining the following environment variables, which are all required
  - `CRAFT_CACHE_DRIVER`
  - `CRAFT_SESSION_DRIVER`
  - `CRAFT_QUEUE_DRIVER`
- removed environment variable `REDIS_ENABLED`